### PR TITLE
Split release configuration into two files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,9 @@ apply plugin: 'maven'
 apply plugin: 'uploadAuth'
 apply plugin: 'me.champeau.gradle.jmh'
 
+apply from: 'gradle/release-duramen.gradle'
+apply from: 'gradle/release.gradle'
+
 sourceCompatibility = 1.7
 targetCompatibility = 1.7
 
@@ -60,8 +63,6 @@ jmh {
 	fork = 1
 	forceGC = true
 }
-
-apply from: 'gradle/release.gradle'
 
 task wrapper(type: Wrapper) {
 	gradleVersion = '1.12'

--- a/gradle/release-duramen.gradle
+++ b/gradle/release-duramen.gradle
@@ -1,0 +1,33 @@
+//Release related configuration for Gradle based project - a project specific part - Duramen
+
+ext.vendor = "Codearte"
+
+ext.mavenPomClosure = {
+	name 'Duramen'
+	description 'Duramen - Java persistent event bus'
+	packaging 'jar'
+	url 'http://codearte.github.io/duramen'
+	licenses {
+		license {
+			name 'The Apache Software License, Version 2.0'
+			url 'http://www.apache.org/licenses/LICENSE-2.0'
+			distribution 'repo'
+		}
+	}
+	developers {
+		developer {
+			id 'jkubrynski'
+			name 'Jakub Kubryński'
+			email 'jkubrynski ATT gmail DOTT com'
+			roles {
+				role 'despot'
+				role 'developer'
+			}
+		}
+	}
+	scm {
+		connection 'scm:git:git@github.com:Codearte/duramen.git'
+		developerConnection 'scm:git:git@github.com:Codearte/duramen.git'
+		url 'https://github.com/Codearte/duramen'
+	}
+}

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -1,3 +1,9 @@
+//Release related configuration for Gradle based project - a project agnostic part
+//
+//Note: this code was designed to be used with a project specific part (should be earlier applied from build.gradle)
+// which defines `ext.mavenPomClosure` passed as a parameter to org.gradle.api.artifacts.maven.MavenPom.project(Closure pom)
+// and `ext.vendor` used in JAR manifest for "Implementation-Vendor".
+
 ext.isReleaseVersion = !project.version.endsWith("SNAPSHOT")
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
@@ -19,10 +25,10 @@ artifacts {
 jar {
 	manifest {
 		attributes(
-				"Application-Name": "Duramen",
-				"Implementation-Title": "Duramen",
+				"Application-Name": name?.capitalize(),
+				"Implementation-Title": name?.capitalize(),
 				"Implementation-Version": version,
-				"Implementation-Vendor": 'Codearte',
+				"Implementation-Vendor": vendor,
 				'Built-Date': new Date(),
 				'Built-JDK': System.properties['java.version'],
 				'Built-Gradle': gradle.gradleVersion,
@@ -57,7 +63,10 @@ if (isReleaseVersion) {
 uploadArchives {
 	repositories {
 		mavenDeployer {
-			repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+			repository(id: 'sonatype-nexus-staging', url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+				authentication(userName: sonatypeUsername, password: sonatypePassword)
+			}
+			snapshotRepository(id: 'sonatype-nexus-snapshots', url: 'https://oss.sonatype.org/content/repositories/snapshots') {
 				authentication(userName: sonatypeUsername, password: sonatypePassword)
 			}
 			name = 'Sonatype OSS'
@@ -68,36 +77,7 @@ uploadArchives {
 				}
 			}
 
-			pom.project {
-				name 'Duramen'
-				description 'Duramen - Java persistent event bus'
-				packaging 'jar'
-				url 'http://codearte.github.io/duramen'
-				licenses {
-					license {
-						name 'The Apache Software License, Version 2.0'
-						url 'http://www.apache.org/licenses/LICENSE-2.0'
-						distribution 'repo'
-					}
-				}
-				developers {
-					developer {
-						id 'jkubrynski'
-						name 'Jakub Kubryński'
-						email 'jkubrynski ATT gmail DOTT com'
-						roles {
-							role 'despot'
-							role 'developer'
-						}
-					}
-				}
-				scm {
-					connection 'scm:git:git@github.com:Codearte/duramen.git'
-					developerConnection 'scm:git:git@github.com:Codearte/duramen.git'
-					url 'https://github.com/Codearte/duramen'
-				}
-
-			}
+			pom.project mavenPomClosure
 		}
 	}
 }


### PR DESCRIPTION
There is one project agnostic part (release.gradle) which can be used
in various project and project specific part (release-durament.gradle)
which defines pon.xml content and other project specific release
settings.
By the way an ability to publish snapshots was added.
